### PR TITLE
Set jdk 11 for java compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,11 @@ pluginBundle {
     tags = listOf("jasm", "assembler")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.withType<KotlinCompile>().all {
     kotlinOptions {
         jvmTarget = "11"


### PR DESCRIPTION
In the current configure only the classes produced by Kotlin are supported by jdk 11 but the `.module` file published to maven to define 17.
```json
{
  "formatVersion": "1.1",
  "component": {
    "group": "com.roscopeco.jasm",
    "module": "jasm-gradle-plugin",
    "version": "0.8.0-SNAPSHOT",
    "attributes": {
      "org.gradle.status": "integration"
    }
  },
  "createdBy": {
    "gradle": {
      "version": "7.2"
    }
  },
  "variants": [
    {
      "name": "apiElements",
      "attributes": {
        "org.gradle.category": "library",
        "org.gradle.dependency.bundling": "external",
        "org.gradle.jvm.environment": "standard-jvm",
        "org.gradle.jvm.version": 17,        <<< this line
        "org.gradle.libraryelements": "jar",
        "org.gradle.usage": "java-api",
        "org.jetbrains.kotlin.platform.type": "jvm"
      },
      "dependencies": [
        {
          "group": "org.jetbrains.kotlin",
          "module": "kotlin-stdlib-jdk8",
          "version": {
            "requires": "1.6.10"
          }
        }
      ],
      "files": [
        {
          "name": "jasm-gradle-plugin-0.8.0-SNAPSHOT.jar",
          "url": "jasm-gradle-plugin-0.8.0-SNAPSHOT.jar",
          "size": 21647,
          "sha512": "f08a28b53ab303f23988a387aa87daf14d9f4f6cac46f05e96171c7517678c895d2e3d7941a2f9a3a732c2e4e44b7c643d8d4ed27cc623911e4f794a5e48b6fb",
          "sha256": "3873b0ac3bd2200d4200b418b2e038e19cdc2a598ba2453730ff8fbcf7494d44",
          "sha1": "22243d104ecd35c9d0961d9e09e4624d5e9659fe",
          "md5": "03f996ae6c73cb1191fb1c647ce68c59"
        }
      ]
    },
    // ....
  ]
}
```

Add java compatibility configure can fix it.
```kotlin
java {
    sourceCompatibility = JavaVersion.VERSION_11
    targetCompatibility = JavaVersion.VERSION_11
}
```